### PR TITLE
Use absolute imports for application modules

### DIFF
--- a/money_metrics/main.py
+++ b/money_metrics/main.py
@@ -1,6 +1,6 @@
 import sys
 from PySide6.QtWidgets import QApplication
-from ui.main_window import MainWindow
+from money_metrics.ui.main_window import MainWindow
 
 def main():
     app = QApplication(sys.argv)

--- a/money_metrics/ui/main_window.py
+++ b/money_metrics/ui/main_window.py
@@ -17,7 +17,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt
 
-from core.data_manager import DataManager
+from money_metrics.core.data_manager import DataManager
 from .graph_screen import GraphScreen
 
 class MainWindow(QMainWindow):


### PR DESCRIPTION
## Summary
- Switch `main` module to import `MainWindow` via the fully-qualified `money_metrics.ui.main_window` path.
- Update `MainWindow` to import `DataManager` from `money_metrics.core.data_manager`.

## Testing
- `pytest`
- `QT_QPA_PLATFORM=offscreen timeout 1 python -m money_metrics.main` *(fails: ImportError: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689d0898b90c832593dfe0d591020388