### PR TITLE
Handle duplicate dataset names

### DIFF
--- a/money_metrics/core/data_manager.py
+++ b/money_metrics/core/data_manager.py
@@ -9,8 +9,22 @@ class DataManager:
     def __init__(self):
         self._datasets = {}
 
-    def add_dataset(self, name, data):
-        """Store a dataset under a given name."""
+    def add_dataset(self, name, data, replace=False):
+        """Store a dataset under a given name.
+
+        Parameters
+        ----------
+        name: str
+            Identifier for the dataset.
+        data: Any
+            Data associated with the ``name``.
+        replace: bool, optional
+            If ``True``, overwrite an existing dataset with the same
+            ``name``. If ``False`` (default), attempting to add a
+            duplicate will raise :class:`ValueError`.
+        """
+        if not replace and name in self._datasets:
+            raise ValueError(f"Dataset '{name}' already exists")
         self._datasets[name] = data
 
     def remove_dataset(self, name):

--- a/money_metrics/ui/main_window.py
+++ b/money_metrics/ui/main_window.py
@@ -29,7 +29,8 @@ class MainWindow(QMainWindow):
         # Data manager keeps datasets separate from the UI widgets
         self.data_manager = DataManager()
         # Example dataset for demonstration purposes
-        self.data_manager.add_dataset("Sample", [1, 2, 3, 4])
+        # `replace=True` ensures re-running won't raise if the dataset exists
+        self.data_manager.add_dataset("Sample", [1, 2, 3, 4], replace=True)
 
         # Placeholder central widget
         central_widget = QWidget()

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -1,0 +1,21 @@
+import pytest
+
+from money_metrics.core import DataManager
+
+
+def test_add_dataset_duplicate_raises():
+    dm = DataManager()
+    dm.add_dataset("sample", [1])
+
+    with pytest.raises(ValueError):
+        dm.add_dataset("sample", [2])
+
+
+def test_add_dataset_replace_overwrites():
+    dm = DataManager()
+    dm.add_dataset("sample", [1])
+
+    dm.add_dataset("sample", [2], replace=True)
+
+    assert dm.get_dataset("sample") == [2]
+


### PR DESCRIPTION
## Summary
- prevent duplicate datasets in `DataManager.add_dataset`
- allow explicit replacement with `replace=True`
- update sample dataset creation and add tests for duplicates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d08a3ac04832585968735bc380eb3