### PR TITLE
Add data manager tests and duplicate check

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,11 @@ Simple PySide6 based application for experimenting with financial data.
 * Modular graph screens that can be added, renamed, detached or removed.
 * Data is stored separately from graph widgets allowing the user to choose
   which datasets to display.
+
+## Running tests
+
+Install the dependencies from ``requirements.txt`` and run the test suite
+using ``pytest``::
+
+    pip install -r requirements.txt
+    pytest

--- a/money_metrics/core/data_manager.py
+++ b/money_metrics/core/data_manager.py
@@ -10,7 +10,13 @@ class DataManager:
         self._datasets = {}
 
     def add_dataset(self, name, data):
-        """Store a dataset under a given name."""
+        """Store a dataset under a given name.
+
+        Raises:
+            ValueError: If a dataset with ``name`` already exists.
+        """
+        if name in self._datasets:
+            raise ValueError(f"Dataset '{name}' already exists")
         self._datasets[name] = data
 
     def remove_dataset(self, name):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PySide6
+pytest

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -1,0 +1,27 @@
+import pytest
+
+from money_metrics.core.data_manager import DataManager
+
+
+def test_add_and_get_dataset():
+    manager = DataManager()
+    data = [1, 2, 3]
+    manager.add_dataset("prices", data)
+    assert manager.get_dataset("prices") == data
+    assert manager.get_dataset("unknown") is None
+
+
+def test_remove_dataset():
+    manager = DataManager()
+    manager.add_dataset("prices", [1, 2, 3])
+    manager.remove_dataset("prices")
+    assert manager.get_dataset("prices") is None
+    # Removing again should not raise an error
+    manager.remove_dataset("prices")
+
+
+def test_add_dataset_duplicate_name_raises():
+    manager = DataManager()
+    manager.add_dataset("prices", [1, 2, 3])
+    with pytest.raises(ValueError):
+        manager.add_dataset("prices", [4, 5, 6])


### PR DESCRIPTION
## Summary
- prevent overwriting existing datasets by raising a ValueError in DataManager.add_dataset
- cover add, get, remove and duplicate scenarios with new pytest suite
- document how to install dependencies and run tests

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d08a51e788325ab748ee804144e9e