### PR TITLE
Protect DataManager datasets from external mutation

### DIFF
--- a/money_metrics/core/data_manager.py
+++ b/money_metrics/core/data_manager.py
@@ -1,9 +1,14 @@
+import copy
+
+
 class DataManager:
     """Simple in-memory data storage for graphing datasets.
 
     This class keeps the graph data separate from the UI components. Graph
     screens can query datasets by name when the user chooses to attach data to
-    a graph.
+    a graph.  The manager defends its internal state by storing and returning
+    copies of datasets so that callers cannot accidentally mutate what is
+    stored.
     """
 
     def __init__(self):
@@ -22,10 +27,17 @@ class DataManager:
             If ``True``, overwrite an existing dataset with the same
             ``name``. If ``False`` (default), attempting to add a
             duplicate will raise :class:`ValueError`.
+
+        Notes
+        -----
+        A deep copy of ``data`` is stored to prevent external modification of
+        the internal dataset after it has been added.
         """
         if not replace and name in self._datasets:
             raise ValueError(f"Dataset '{name}' already exists")
-        self._datasets[name] = data
+        # Store a copy so future modifications to the original object do not
+        # alter the stored dataset.
+        self._datasets[name] = copy.deepcopy(data)
 
     def remove_dataset(self, name):
         """Remove a dataset if it exists."""
@@ -34,6 +46,10 @@ class DataManager:
     def get_dataset(self, name):
         """Retrieve a dataset by name.
 
-        Returns ``None`` if the dataset is unknown.
+        Returns
+        -------
+        Any or ``None``
+            A deep copy of the dataset or ``None`` if the dataset is unknown.
         """
-        return self._datasets.get(name)
+        data = self._datasets.get(name)
+        return None if data is None else copy.deepcopy(data)

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -19,3 +19,26 @@ def test_add_dataset_replace_overwrites():
 
     assert dm.get_dataset("sample") == [2]
 
+
+def test_add_dataset_stores_copy():
+    dm = DataManager()
+    data = [1, 2, 3]
+    dm.add_dataset("numbers", data)
+    # mutate original data after adding
+    data.append(4)
+
+    # stored dataset should not be affected
+    assert dm.get_dataset("numbers") == [1, 2, 3]
+
+
+def test_get_dataset_returns_copy():
+    dm = DataManager()
+    dm.add_dataset("numbers", [1, 2, 3])
+
+    retrieved = dm.get_dataset("numbers")
+    # mutate retrieved dataset
+    retrieved.append(4)
+
+    # internal dataset remains unchanged
+    assert dm.get_dataset("numbers") == [1, 2, 3]
+


### PR DESCRIPTION
## Summary
- ensure DataManager stores and returns deep copies of datasets to prevent accidental mutation
- document new defensive behavior and add comprehensive tests for mutation protection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d10696f888325888df05f67378235