### PR TITLE
Pin PySide6 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-PySide6
+PySide6==6.6.0


### PR DESCRIPTION
## Summary
- pin PySide6 requirement to version 6.6.0 for cross-platform stability

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0ea69452083259b7eb3c953a8da35