### PR TITLE
Add setup script for virtual environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,23 +13,28 @@ Simple PySide6 based application for experimenting with financial data.
 ### Prerequisites
 - Python 3.10+
 
-### macOS/Linux
-```bash
-python3 -m venv venv
-source venv/bin/activate
-```
+### Automatic setup
 
-### Windows
-```bash
-python -m venv venv
-venv\\Scripts\\activate
-```
-
-Install dependencies:
+Create a virtual environment and install dependencies with the provided script:
 
 ```bash
-pip install -r requirements.txt
+python setup_env.py            # runtime dependencies only
+python setup_env.py --dev      # include dev/test requirements (optional)
 ```
+
+### Activate the environment
+
+- **macOS/Linux**
+
+  ```bash
+  source venv/bin/activate
+  ```
+
+- **Windows**
+
+  ```bash
+  venv\Scripts\activate
+  ```
 
 ## Run the app
 
@@ -42,11 +47,11 @@ python main.py
 
 ## Run tests
 
-For contributors who wish to run the test suite, first install the optional
-development requirements:
+For contributors who wish to run the test suite, install the additional
+development requirements (if not already installed) with:
 
 ```bash
-pip install -r requirements-dev.txt
+python setup_env.py --dev
 ```
 
 ### Pytest

--- a/setup_env.py
+++ b/setup_env.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Bootstrap script to create a virtual environment and install dependencies.
+
+Usage:
+    python setup_env.py            # Install runtime dependencies
+    python setup_env.py --dev      # Include dev dependencies (tests, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import subprocess
+import sys
+import venv
+
+
+def run(cmd: list[str]) -> None:
+    """Run a subprocess and exit on failure."""
+    subprocess.check_call(cmd)
+
+
+def main() -> None:
+    if sys.version_info < (3, 10):
+        raise RuntimeError("Python 3.10+ is required.")
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dev",
+        action="store_true",
+        help="Install additional development requirements.",
+    )
+    args = parser.parse_args()
+
+    env_dir = os.path.join(os.path.dirname(__file__), "venv")
+    print(f"Creating virtual environment at {env_dir!r} …")
+    venv.EnvBuilder(with_pip=True).create(env_dir)
+
+    if platform.system() == "Windows":
+        python = os.path.join(env_dir, "Scripts", "python.exe")
+        pip = os.path.join(env_dir, "Scripts", "pip.exe")
+    else:
+        python = os.path.join(env_dir, "bin", "python")
+        pip = os.path.join(env_dir, "bin", "pip")
+
+    print("Installing runtime dependencies …")
+    run([pip, "install", "--upgrade", "pip"])
+    run([pip, "install", "-r", "requirements.txt"])
+
+    if args.dev:
+        print("Installing development dependencies …")
+        run([pip, "install", "-r", "requirements-dev.txt"])
+
+    print("\nSetup complete!")
+    print(
+        "Activate the environment with:\n  source venv/bin/activate (macOS/Linux)\n  venv\\Scripts\\activate (Windows)"
+    )
+    print(f"Run the application using:\n  {python} main.py")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `setup_env.py` to bootstrap a virtualenv and install dependencies
- document automatic environment setup in README

## Testing
- `python setup_env.py --dev` *(fails: Could not find a version that satisfies the requirement PySide6==6.6.0)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a10392b330832580168329f831d558