### PR TITLE
Refactor entry point and clean up project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ python setup_env.py --dev      # include dev/test requirements (optional)
 
 ## Run the app
 
-The application's entry point is `money_metrics.main.main`, exposed via the
-top-level `main.py` helper script. Launch the program with:
+The application can be launched directly as a module thanks to the
+``money_metrics.__main__`` entry point:
 
 ```bash
-python main.py
+python -m money_metrics
 ```
 
 ## Run tests

--- a/main.py
+++ b/main.py
@@ -1,4 +1,0 @@
-from money_metrics.main import main
-
-if __name__ == "__main__":
-    main()

--- a/money_metrics/__init__.py
+++ b/money_metrics/__init__.py
@@ -1,0 +1,3 @@
+"""MoneyMetrics package."""
+
+__all__: list[str] = []

--- a/money_metrics/__main__.py
+++ b/money_metrics/__main__.py
@@ -1,0 +1,6 @@
+"""Module executed when running `python -m money_metrics`."""
+
+from .app import main
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    main()

--- a/money_metrics/app.py
+++ b/money_metrics/app.py
@@ -1,12 +1,15 @@
+"""Application bootstrap for MoneyMetrics."""
+
 import sys
 from PySide6.QtWidgets import QApplication
+
 from money_metrics.ui.main_window import MainWindow
 
-def main():
+
+def main() -> None:
+    """Launch the MoneyMetrics GUI."""
     app = QApplication(sys.argv)
     window = MainWindow()
     window.show()
     sys.exit(app.exec())
 
-if __name__ == "__main__":
-    main()

--- a/setup_env.py
+++ b/setup_env.py
@@ -57,7 +57,7 @@ def main() -> None:
     print(
         "Activate the environment with:\n  source venv/bin/activate (macOS/Linux)\n  venv\\Scripts\\activate (Windows)"
     )
-    print(f"Run the application using:\n  {python} main.py")
+    print(f"Run the application using:\n  {python} -m money_metrics")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace duplicated main scripts with a single `money_metrics` module entry point
- rename package `main.py` to `app.py` and add `__main__` for `python -m money_metrics`
- update README and setup script for new launch command

## Testing
- `pytest`
- `python -m money_metrics` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a1064063c88325ab3ccf4af7cea79c