### PR TITLE
fix QAction import location for PySide6

### DIFF
--- a/money_metrics/ui/main_window.py
+++ b/money_metrics/ui/main_window.py
@@ -13,8 +13,8 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
     QMenuBar,
-    QAction,
 )
+from PySide6.QtGui import QAction
 from PySide6.QtCore import Qt
 
 from money_metrics.core.data_manager import DataManager


### PR DESCRIPTION
## Summary
- adjust main window imports to fetch QAction from PySide6.QtGui instead of PySide6.QtWidgets

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1085aebb483259785a4f2e6f58096