### PR TITLE
Add local profile support

### DIFF
--- a/money_metrics/app.py
+++ b/money_metrics/app.py
@@ -1,15 +1,22 @@
 """Application bootstrap for MoneyMetrics."""
 
 import sys
-from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication, QFileDialog
 
 from money_metrics.ui.main_window import MainWindow
+from money_metrics.core.profile import AppProfile
 
 
 def main() -> None:
     """Launch the MoneyMetrics GUI."""
     app = QApplication(sys.argv)
-    window = MainWindow()
+    path, _ = QFileDialog.getOpenFileName(
+        None, "Open Profile", filter="MoneyMetrics Profile (*.json)"
+    )
+    profile = AppProfile.load_from_file(path) if path else None
+    window = MainWindow(profile)
+    if path:
+        window.profile_path = path
     window.show()
     sys.exit(app.exec())
 

--- a/money_metrics/core/__init__.py
+++ b/money_metrics/core/__init__.py
@@ -1,5 +1,6 @@
 """Core utilities for MoneyMetrics."""
 
 from .data_manager import DataManager
+from .profile import AppProfile
 
-__all__ = ["DataManager"]
+__all__ = ["DataManager", "AppProfile"]

--- a/money_metrics/core/data_manager.py
+++ b/money_metrics/core/data_manager.py
@@ -53,3 +53,17 @@ class DataManager:
         """
         data = self._datasets.get(name)
         return None if data is None else copy.deepcopy(data)
+
+    # ------------------------------------------------------------------
+    def all_datasets(self):
+        """Return a deep copy of all stored datasets.
+
+        The returned mapping can be freely modified by callers without
+        affecting the internal state of the manager.  It is primarily used for
+        serialising the application state to a profile.
+        """
+        return copy.deepcopy(self._datasets)
+
+    def clear(self):
+        """Remove all datasets from the manager."""
+        self._datasets.clear()

--- a/money_metrics/core/profile.py
+++ b/money_metrics/core/profile.py
@@ -1,0 +1,61 @@
+import json
+from dataclasses import dataclass, field
+from typing import Dict, List, Any
+
+
+@dataclass
+class AppProfile:
+    """Serializable representation of a user's application setup.
+
+    The profile stores datasets managed by :class:`DataManager` alongside a
+    minimal description of the current graph screens. Profiles can be saved to
+    and loaded from JSON files, allowing them to be shared between users or
+    re-used later.
+    """
+
+    datasets: Dict[str, Any] = field(default_factory=dict)
+    screens: List[Dict[str, Any]] = field(default_factory=list)
+    version: int = 1
+
+    # ------------------------------------------------------------------
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "datasets": self.datasets,
+            "screens": self.screens,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AppProfile":
+        version = data.get("version", 1)
+        datasets = data.get("datasets", {})
+        screens = data.get("screens", [])
+        profile = cls(datasets=datasets, screens=screens)
+        profile.version = version
+        return profile
+
+    # ------------------------------------------------------------------
+    def save_to_file(self, path: str) -> None:
+        """Write the profile to ``path`` as JSON."""
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(self.to_dict(), fh, indent=2)
+
+    @classmethod
+    def load_from_file(cls, path: str) -> "AppProfile":
+        """Load a profile from ``path``."""
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return cls.from_dict(data)
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_window(cls, window) -> "AppProfile":
+        """Create a profile from the current state of a main window."""
+        datasets = window.data_manager.all_datasets()
+        screens: List[Dict[str, Any]] = []
+        for graph in window.graph_screens:
+            screens.append({
+                "title": graph.windowTitle(),
+                "dataset": getattr(graph, "dataset_name", None),
+            })
+        return cls(datasets=datasets, screens=screens)

--- a/money_metrics/ui/graph_screen.py
+++ b/money_metrics/ui/graph_screen.py
@@ -18,6 +18,7 @@ class GraphScreen(QDockWidget):
         super().__init__(title, parent)
         self.data_manager = data_manager
         self.data = None
+        self.dataset_name = None
 
         content = QWidget(self)
         layout = QVBoxLayout(content)
@@ -27,7 +28,7 @@ class GraphScreen(QDockWidget):
         self.setWidget(content)
 
     # ------------------------ Data handling -------------------------
-    def set_data(self, data):
+    def set_data(self, data, name=None):
         """Assign data to the graph screen.
 
         Parameters
@@ -35,8 +36,12 @@ class GraphScreen(QDockWidget):
         data: Any
             Data to be visualised. For this stub implementation the data is
             simply converted to a string and displayed in the label.
+        name: str, optional
+            Name of the dataset, stored so the screen can be recreated when a
+            profile is loaded.
         """
         self.data = data
+        self.dataset_name = name
         if data is None:
             self.label.setText("No data")
         else:
@@ -72,4 +77,4 @@ class GraphScreen(QDockWidget):
         if data is None:
             QMessageBox.warning(self, "Data not found", f"Dataset '{name}' not found.")
             return
-        self.set_data(data)
+        self.set_data(data, name)

--- a/money_metrics/ui/main_window.py
+++ b/money_metrics/ui/main_window.py
@@ -13,24 +13,23 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
     QMenuBar,
+    QFileDialog,
 )
 from PySide6.QtGui import QAction
 from PySide6.QtCore import Qt
 
 from money_metrics.core.data_manager import DataManager
+from money_metrics.core.profile import AppProfile
 from .graph_screen import GraphScreen
 
 class MainWindow(QMainWindow):
-    def __init__(self):
+    def __init__(self, profile: AppProfile | None = None):
         super().__init__()
         self.setWindowTitle("MoneyMetrics")
         self.setGeometry(100, 100, 800, 600)
 
         # Data manager keeps datasets separate from the UI widgets
         self.data_manager = DataManager()
-        # Example dataset for demonstration purposes
-        # `replace=True` ensures re-running won't raise if the dataset exists
-        self.data_manager.add_dataset("Sample", [1, 2, 3, 4], replace=True)
 
         # Placeholder central widget
         central_widget = QWidget()
@@ -39,7 +38,10 @@ class MainWindow(QMainWindow):
         self.setCentralWidget(central_widget)
 
         # Keep track of graph screens
-        self.graph_screens = []
+        self.graph_screens: list[GraphScreen] = []
+
+        # Track profile path
+        self.profile_path: str | None = None
 
         # Menu setup
         menu_bar = QMenuBar(self)
@@ -48,6 +50,25 @@ class MainWindow(QMainWindow):
         add_graph_action = QAction("Add Graph", self)
         add_graph_action.triggered.connect(self.add_graph_screen)
         graphs_menu.addAction(add_graph_action)
+
+        # Profile menu
+        profile_menu = menu_bar.addMenu("Profile")
+        load_action = QAction("Load Profile...", self)
+        load_action.triggered.connect(self._load_profile_dialog)
+        save_action = QAction("Save Profile", self)
+        save_action.triggered.connect(self._save_profile)
+        save_as_action = QAction("Save Profile As...", self)
+        save_as_action.triggered.connect(self._save_profile_as)
+        profile_menu.addAction(load_action)
+        profile_menu.addAction(save_action)
+        profile_menu.addAction(save_as_action)
+
+        if profile is not None:
+            self._apply_profile(profile)
+        else:
+            # Example dataset for demonstration purposes
+            # `replace=True` ensures re-running won't raise if the dataset exists
+            self.data_manager.add_dataset("Sample", [1, 2, 3, 4], replace=True)
 
     # ------------------------------------------------------------------
     def add_graph_screen(self):
@@ -61,3 +82,50 @@ class MainWindow(QMainWindow):
         """Remove a graph screen once it has been destroyed."""
         if screen in self.graph_screens:
             self.graph_screens.remove(screen)
+
+    # ------------------------------------------------------------------
+    def _apply_profile(self, profile: AppProfile) -> None:
+        """Load datasets and graph screens from a profile."""
+        self.data_manager = DataManager()
+        for name, data in profile.datasets.items():
+            self.data_manager.add_dataset(name, data, replace=True)
+
+        # Remove existing screens
+        for screen in list(self.graph_screens):
+            screen.deleteLater()
+        self.graph_screens.clear()
+
+        for info in profile.screens:
+            graph = GraphScreen(self.data_manager, self, title=info.get("title"))
+            dataset_name = info.get("dataset")
+            if dataset_name:
+                data = self.data_manager.get_dataset(dataset_name)
+                if data is not None:
+                    graph.set_data(data, dataset_name)
+            graph.destroyed.connect(self._remove_graph_screen)
+            self.addDockWidget(Qt.RightDockWidgetArea, graph)
+            self.graph_screens.append(graph)
+
+    def _save_profile(self) -> None:
+        if self.profile_path is None:
+            self._save_profile_as()
+            return
+        profile = AppProfile.from_window(self)
+        profile.save_to_file(self.profile_path)
+
+    def _save_profile_as(self) -> None:
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save Profile", filter="MoneyMetrics Profile (*.json)"
+        )
+        if path:
+            self.profile_path = path
+            self._save_profile()
+
+    def _load_profile_dialog(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Load Profile", filter="MoneyMetrics Profile (*.json)"
+        )
+        if path:
+            profile = AppProfile.load_from_file(path)
+            self.profile_path = path
+            self._apply_profile(profile)

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -42,3 +42,12 @@ def test_get_dataset_returns_copy():
     # internal dataset remains unchanged
     assert dm.get_dataset("numbers") == [1, 2, 3]
 
+
+def test_all_datasets_returns_copy():
+    dm = DataManager()
+    dm.add_dataset("sample", [1, 2, 3])
+    datasets = dm.all_datasets()
+    datasets["sample"].append(4)
+
+    assert dm.get_dataset("sample") == [1, 2, 3]
+

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,14 @@
+from money_metrics.core.profile import AppProfile
+
+
+def test_profile_round_trip(tmp_path):
+    profile = AppProfile(
+        datasets={"numbers": [1, 2, 3]},
+        screens=[{"title": "Graph 1", "dataset": "numbers"}],
+    )
+    path = tmp_path / "profile.json"
+    profile.save_to_file(path)
+    loaded = AppProfile.load_from_file(path)
+
+    assert loaded.datasets == profile.datasets
+    assert loaded.screens == profile.screens


### PR DESCRIPTION
## Summary
- Allow saving/loading app profiles with datasets and graph screens
- Track active profile in UI and expose actions for saving/loading
- Prompt for profile selection at startup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a10cc4d0588325887d861652fa370b