### PR TITLE
Add 401(k) dataset management and graph/table views

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Simple PySide6 based application for experimenting with financial data.
 * Modular graph screens that can be added, renamed, detached or removed.
 * Data is stored separately from graph widgets allowing the user to choose
   which datasets to display.
+* Built-in 401(k) dataset support with editable monthly contributions and
+  graph/table visualisation.
 
 ## Setup
 

--- a/money_metrics/core/__init__.py
+++ b/money_metrics/core/__init__.py
@@ -2,5 +2,6 @@
 
 from .data_manager import DataManager
 from .profile import AppProfile
+from .four_zero_one_k import FourZeroOneK, Entry
 
-__all__ = ["DataManager", "AppProfile"]
+__all__ = ["DataManager", "AppProfile", "FourZeroOneK", "Entry"]

--- a/money_metrics/core/four_zero_one_k.py
+++ b/money_metrics/core/four_zero_one_k.py
@@ -1,0 +1,107 @@
+"""Utilities for managing 401(k) datasets.
+
+The :class:`FourZeroOneK` class stores monthly contribution data and the
+resulting account balance after applying a growth rate.  The dataset is stored
+as a list of dictionaries so it can be serialised directly to JSON for
+inclusion in an :class:`~money_metrics.core.profile.AppProfile`.
+
+Inputs such as the monthly contribution and growth rate are kept alongside the
+output balance, allowing the data to be graphed or displayed in tabular form by
+the UI.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import List, Dict, Iterable
+
+
+@dataclass
+class Entry:
+    """Single month of 401(k) data."""
+
+    month: int
+    contribution: float
+    growth_rate: float
+    balance: float
+
+
+class FourZeroOneK:
+    """Simple 401(k) tracker with add/modify/delete operations.
+
+    The internal ``entries`` list is maintained in chronological order. Each
+    operation that alters the sequence will recompute the balance of the
+    affected month and all subsequent months.
+    """
+
+    def __init__(self, entries: Iterable[Dict[str, float]] | None = None):
+        self.entries: List[Entry] = []
+        if entries:
+            for item in entries:
+                self.entries.append(Entry(**item))
+            # ensure balances are consistent when loading external data
+            self._recalculate_from(0)
+
+    # ------------------------------------------------------------------
+    def add_month(self, contribution: float, growth_rate: float) -> None:
+        """Append a new month to the dataset."""
+
+        prev_balance = self.entries[-1].balance if self.entries else 0.0
+        balance = (prev_balance + contribution) * (1 + growth_rate)
+        self.entries.append(
+            Entry(len(self.entries) + 1, contribution, growth_rate, balance)
+        )
+
+    def delete_month(self, month: int) -> None:
+        """Remove a month by index (1-based)."""
+
+        index = month - 1
+        if not (0 <= index < len(self.entries)):
+            raise IndexError("month out of range")
+        del self.entries[index]
+        self._recalculate_from(index)
+
+    def modify_month(
+        self,
+        month: int,
+        *,
+        contribution: float | None = None,
+        growth_rate: float | None = None,
+    ) -> None:
+        """Modify contribution and/or growth rate for a month."""
+
+        index = month - 1
+        if not (0 <= index < len(self.entries)):
+            raise IndexError("month out of range")
+
+        entry = self.entries[index]
+        if contribution is not None:
+            entry.contribution = contribution
+        if growth_rate is not None:
+            entry.growth_rate = growth_rate
+        self.entries[index] = entry
+        self._recalculate_from(index)
+
+    # ------------------------------------------------------------------
+    def to_dict(self) -> List[Dict[str, float]]:
+        """Return the dataset as a list of serialisable dicts."""
+
+        return [asdict(e) for e in self.entries]
+
+    # ------------------------------------------------------------------
+    def _recalculate_from(self, start: int) -> None:
+        """Recompute balances starting at ``start`` index."""
+
+        prev_balance = self.entries[start - 1].balance if start > 0 else 0.0
+        for i in range(start, len(self.entries)):
+            entry = self.entries[i]
+            entry.month = i + 1
+            entry.balance = (prev_balance + entry.contribution) * (
+                1 + entry.growth_rate
+            )
+            self.entries[i] = entry
+            prev_balance = entry.balance
+
+
+__all__ = ["FourZeroOneK", "Entry"]
+

--- a/money_metrics/ui/graph_screen.py
+++ b/money_metrics/ui/graph_screen.py
@@ -1,5 +1,18 @@
-from PySide6.QtWidgets import QDockWidget, QWidget, QVBoxLayout, QLabel, QMenu, QInputDialog, QMessageBox
+from PySide6.QtWidgets import (
+    QDockWidget,
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QMenu,
+    QInputDialog,
+    QMessageBox,
+    QTableWidget,
+    QTableWidgetItem,
+)
 from PySide6.QtCore import Qt
+
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
 
 class GraphScreen(QDockWidget):
     """A dockable widget representing a graph screen.
@@ -21,10 +34,15 @@ class GraphScreen(QDockWidget):
         self.dataset_name = None
 
         content = QWidget(self)
-        layout = QVBoxLayout(content)
+        self._layout = QVBoxLayout(content)
         self.label = QLabel("No data", content)
         self.label.setAlignment(Qt.AlignCenter)
-        layout.addWidget(self.label)
+        self.table = QTableWidget(content)
+        self.canvas = FigureCanvas(Figure(figsize=(5, 3)))
+        self.view_mode = "graph"
+
+        self._layout.addWidget(self.label)
+        self._current_widget = self.label
         self.setWidget(content)
 
     # ------------------------ Data handling -------------------------
@@ -42,23 +60,38 @@ class GraphScreen(QDockWidget):
         """
         self.data = data
         self.dataset_name = name
-        if data is None:
-            self.label.setText("No data")
+
+        if isinstance(data, list) and data and isinstance(data[0], dict):
+            self._update_table(data)
+            self._update_graph(data)
+            widget = self.canvas if self.view_mode == "graph" else self.table
+            self._set_widget(widget)
         else:
-            self.label.setText(str(data))
+            text = "No data" if data is None else str(data)
+            self.label.setText(text)
+            self._set_widget(self.label)
 
     # ------------------------ UI actions ---------------------------
     def contextMenuEvent(self, event):
         menu = QMenu(self)
         rename_action = menu.addAction("Rename")
         data_action = menu.addAction("Set Data")
-        detach_action = menu.addAction("Detach" if not self.isFloating() else "Attach")
+        toggle_action = None
+        if isinstance(self.data, list) and self.data and isinstance(self.data[0], dict):
+            toggle_action = menu.addAction(
+                "Show Table" if self.view_mode == "graph" else "Show Graph"
+            )
+        detach_action = menu.addAction(
+            "Detach" if not self.isFloating() else "Attach"
+        )
         close_action = menu.addAction("Close")
         action = menu.exec(event.globalPos())
         if action == rename_action:
             self._rename()
         elif action == data_action:
             self._prompt_for_data()
+        elif toggle_action and action == toggle_action:
+            self._toggle_view()
         elif action == detach_action:
             self.setFloating(not self.isFloating())
         elif action == close_action:
@@ -78,3 +111,37 @@ class GraphScreen(QDockWidget):
             QMessageBox.warning(self, "Data not found", f"Dataset '{name}' not found.")
             return
         self.set_data(data, name)
+
+    # ------------------------ Helpers ---------------------------
+    def _set_widget(self, widget: QWidget) -> None:
+        if widget is self._current_widget:
+            return
+        self._layout.removeWidget(self._current_widget)
+        self._current_widget.setParent(None)
+        self._layout.addWidget(widget)
+        self._current_widget = widget
+
+    def _update_table(self, data):
+        keys = list(data[0].keys())
+        self.table.setColumnCount(len(keys))
+        self.table.setHorizontalHeaderLabels(keys)
+        self.table.setRowCount(len(data))
+        for row, entry in enumerate(data):
+            for col, key in enumerate(keys):
+                item = QTableWidgetItem(str(entry.get(key, "")))
+                self.table.setItem(row, col, item)
+
+    def _update_graph(self, data):
+        ax = self.canvas.figure.subplots()
+        ax.clear()
+        months = [d.get("month", i + 1) for i, d in enumerate(data)]
+        balances = [d.get("balance", 0) for d in data]
+        ax.plot(months, balances, marker="o")
+        ax.set_xlabel("Month")
+        ax.set_ylabel("Balance")
+        self.canvas.draw_idle()
+
+    def _toggle_view(self):
+        self.view_mode = "table" if self.view_mode == "graph" else "graph"
+        widget = self.canvas if self.view_mode == "graph" else self.table
+        self._set_widget(widget)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 pytest
+matplotlib==3.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PySide6==6.6.0
+matplotlib==3.8.0

--- a/tests/test_four_zero_one_k.py
+++ b/tests/test_four_zero_one_k.py
@@ -1,0 +1,29 @@
+import pytest
+
+from money_metrics.core import FourZeroOneK, DataManager, AppProfile
+
+
+def test_401k_add_modify_delete_and_profile(tmp_path):
+    plan = FourZeroOneK()
+    plan.add_month(100, 0.01)
+    plan.add_month(100, 0.01)
+
+    # balances should compound
+    assert plan.entries[0].balance == pytest.approx(101.0)
+    assert plan.entries[1].balance == pytest.approx((101.0 + 100) * 1.01)
+
+    plan.modify_month(2, contribution=200)
+    assert plan.entries[1].contribution == 200
+
+    plan.delete_month(1)
+    assert plan.entries[0].month == 1
+
+    dm = DataManager()
+    dm.add_dataset("401k", plan.to_dict())
+    profile = AppProfile(datasets=dm.all_datasets())
+    path = tmp_path / "profile.json"
+    profile.save_to_file(path)
+    loaded = AppProfile.load_from_file(path)
+    assert "401k" in loaded.datasets
+    assert loaded.datasets["401k"] == plan.to_dict()
+


### PR DESCRIPTION
## Summary
- add `FourZeroOneK` helper for storing monthly 401(k) contributions and growth
- enable graph screens to show data as matplotlib plot or table and allow view toggling
- document 401(k) support in README and add regression tests

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement matplotlib==3.8.0)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a2335b6098832580f0a32dd2d17ced