### PR TITLE
Expose core API for 401(k) dataset

### DIFF
--- a/money_metrics/__init__.py
+++ b/money_metrics/__init__.py
@@ -1,3 +1,13 @@
-"""MoneyMetrics package."""
+"""MoneyMetrics package.
 
-__all__: list[str] = []
+This top-level package re-exports the core classes so that users can
+conveniently access them via ``import money_metrics``. Previously, the
+core utilities such as :class:`~money_metrics.core.FourZeroOneK` were only
+available through the :mod:`money_metrics.core` submodule, which made it
+awkward for callers to build 401(k) datasets. By exposing the classes here
+we provide a simpler interface for consumers of the library.
+"""
+
+from .core import DataManager, AppProfile, FourZeroOneK, Entry
+
+__all__ = ["DataManager", "AppProfile", "FourZeroOneK", "Entry"]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,13 @@
+from money_metrics import FourZeroOneK, DataManager, AppProfile
+
+
+def test_import_and_use_public_api(tmp_path):
+    plan = FourZeroOneK()
+    plan.add_month(100, 0.01)
+    dm = DataManager()
+    dm.add_dataset("401k", plan.to_dict())
+    profile = AppProfile(datasets=dm.all_datasets())
+    path = tmp_path / "profile.json"
+    profile.save_to_file(path)
+    loaded = AppProfile.load_from_file(path)
+    assert "401k" in loaded.datasets


### PR DESCRIPTION
## Summary
- Re-export core utilities like FourZeroOneK at the top-level package so users can build 401(k) datasets via `import money_metrics`
- Add regression test ensuring public API works

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2386c7f68832585095d69cbb3a3e5