### PR TITLE
Start app directly and add finance menu

### DIFF
--- a/money_metrics/app.py
+++ b/money_metrics/app.py
@@ -1,22 +1,15 @@
 """Application bootstrap for MoneyMetrics."""
 
 import sys
-from PySide6.QtWidgets import QApplication, QFileDialog
+from PySide6.QtWidgets import QApplication
 
 from money_metrics.ui.main_window import MainWindow
-from money_metrics.core.profile import AppProfile
 
 
 def main() -> None:
     """Launch the MoneyMetrics GUI."""
     app = QApplication(sys.argv)
-    path, _ = QFileDialog.getOpenFileName(
-        None, "Open Profile", filter="MoneyMetrics Profile (*.json)"
-    )
-    profile = AppProfile.load_from_file(path) if path else None
-    window = MainWindow(profile)
-    if path:
-        window.profile_path = path
+    window = MainWindow()
     window.show()
     sys.exit(app.exec())
 


### PR DESCRIPTION
## Summary
- Start application without prompting for a profile file; profiles can now be loaded later via the Profile menu
- Introduce a Finance menu allowing users to add a 401(k) dataset with contribution, growth rate, and duration inputs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a23bfb6d248325994209f1aa98b13d