### PR TITLE
Add default tabbed home layout and profile switching

### DIFF
--- a/money_metrics/ui/main_window.py
+++ b/money_metrics/ui/main_window.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import (
     QFileDialog,
     QInputDialog,
     QMessageBox,
+    QTabWidget,
 )
 from PySide6.QtGui import QAction
 from PySide6.QtCore import Qt
@@ -34,11 +35,14 @@ class MainWindow(QMainWindow):
         # Data manager keeps datasets separate from the UI widgets
         self.data_manager = DataManager()
 
-        # Placeholder central widget
-        central_widget = QWidget()
-        layout = QVBoxLayout(central_widget)
+        # Default home layout with tabs at the top
+        self.home_tabs = QTabWidget()
+        self.home_tabs.setTabPosition(QTabWidget.North)
+        home_tab = QWidget()
+        layout = QVBoxLayout(home_tab)
         layout.addWidget(QLabel("Welcome to MoneyMetrics!"))
-        self.setCentralWidget(central_widget)
+        self.home_tabs.addTab(home_tab, "Home")
+        self.setCentralWidget(self.home_tabs)
 
         # Keep track of graph screens
         self.graph_screens: list[GraphScreen] = []
@@ -136,6 +140,11 @@ class MainWindow(QMainWindow):
     # ------------------------------------------------------------------
     def _apply_profile(self, profile: AppProfile) -> None:
         """Load datasets and graph screens from a profile."""
+        # Replace the default home tabs with a plain central widget
+        if isinstance(self.centralWidget(), QTabWidget):
+            self.centralWidget().deleteLater()
+        self.setCentralWidget(QWidget())
+
         self.data_manager = DataManager()
         for name, data in profile.datasets.items():
             self.data_manager.add_dataset(name, data, replace=True)

--- a/tests/test_main_window_layout.py
+++ b/tests/test_main_window_layout.py
@@ -1,0 +1,32 @@
+import pytest
+
+pytest.importorskip("PySide6.QtWidgets")
+from PySide6.QtWidgets import QApplication, QTabWidget
+
+from money_metrics.ui.main_window import MainWindow
+from money_metrics.core.profile import AppProfile
+
+
+@pytest.fixture(scope="module")
+def app():
+    try:
+        app = QApplication.instance() or QApplication([])
+    except Exception:
+        pytest.skip("Qt GUI not available")
+    yield app
+
+
+def test_default_home_layout_has_tabs(app):
+    window = MainWindow()
+    assert isinstance(window.centralWidget(), QTabWidget)
+    assert window.centralWidget().tabPosition() == QTabWidget.North
+
+
+def test_profile_load_replaces_home_layout(app):
+    profile = AppProfile(
+        datasets={"Sample": [1, 2, 3]},
+        screens=[{"title": "Graph 1", "dataset": "Sample"}],
+    )
+    window = MainWindow()
+    window._apply_profile(profile)
+    assert not isinstance(window.centralWidget(), QTabWidget)


### PR DESCRIPTION
## Summary
- Show a tabbed home screen by default with tabs displayed across the top.
- Replace the default tabs with a plain widget when loading a saved profile.
- Add tests to verify default home layout and profile switching behavior.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3dc4460e88325af0bdf717ad34361