### PR TITLE
Fix graph redraw accumulating axes

### DIFF
--- a/money_metrics/ui/graph_screen.py
+++ b/money_metrics/ui/graph_screen.py
@@ -266,8 +266,17 @@ class GraphScreen(QDockWidget):
     def _update_graph(self, data):
         """Render the selected parameters against months."""
 
-        ax = self.canvas.figure.subplots()
-        ax.clear()
+        # ``Figure.subplots`` creates a new set of axes every time it is
+        # called, which previously caused the figure to accumulate multiple
+        # axes when the graph was refreshed. Reuse the existing axes instead
+        # of adding new ones so repeated calls simply redraw on the same
+        # canvas.
+
+        fig = self.canvas.figure
+        # Clear any existing axes so we start fresh each update
+        fig.clear()
+        ax = fig.add_subplot(111)
+
         if not (isinstance(data, list) and data and isinstance(data[0], dict)):
             self.canvas.draw_idle()
             return

--- a/tests/test_graph_screen.py
+++ b/tests/test_graph_screen.py
@@ -44,6 +44,17 @@ def test_add_and_remove_parameters(app):
     assert "balance" not in labels and "contribution" in labels
 
 
+def test_update_graph_reuses_axes(app):
+    screen = GraphScreen(DataManager())
+    data = sample_dataset()
+    screen.set_data(data, name="401(k)")
+    initial_axes = len(screen.canvas.figure.axes)
+    # Repeated updates should not create additional axes
+    screen._update_graph(data)
+    screen._update_graph(data)
+    assert len(screen.canvas.figure.axes) == initial_axes
+
+
 def _col_index(table, name):
     for i in range(table.columnCount()):
         if table.horizontalHeaderItem(i).text() == name:


### PR DESCRIPTION
## Summary
- prevent GraphScreen from creating extra axes on every redraw
- add regression test ensuring repeated graph updates reuse the same axes

## Testing
- `pytest -q`
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a515ce2bbc832593043b83c91dc644