### PR TITLE
docs: clarify apt-get update usage

### DIFF
--- a/docs/apt_proxy_troubleshooting.md
+++ b/docs/apt_proxy_troubleshooting.md
@@ -1,0 +1,52 @@
+# Fixing `apt-get update` Errors
+
+When running `apt-get update`, you may encounter errors such as:
+
+```
+The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed.
+```
+
+## When should `apt-get update` be used?
+
+`apt-get update` refreshes the package index on Debian-based systems such as
+Ubuntu. Run it when you need to install or upgrade system packages on a
+Debian/Ubuntu machine. Typical scenarios include:
+
+* **Setting up developer workstations or CI runners** that rely on Ubuntu or
+  Debian and need additional APT packages.
+* **Building containers or virtual machines** where you plan to install extra
+  packages after provisioning the image.
+
+The command **should not** be used in these cases:
+
+* **Non-Debian operating systems** (macOS, Windows, Alpine, etc.) that do not
+  use APT.
+* **Environments with all required packages pre-installed**, where updating
+  the package index provides no benefit.
+* **Restricted or offline environments** where outbound network access is
+  blocked; `apt-get update` cannot reach the package mirrors and will fail.
+
+If your workflow does not involve installing new system packages or you are on
+a platform without `apt`, you can skip running this command.
+
+## Root Cause
+In this environment, the `http_proxy` and `https_proxy` environment variables are set to `http://proxy:8080`, which points to a
+proxy that returns `403 Forbidden` to outbound requests. Because the proxy blocks access to the Ubuntu archives, `apt` cannot retrieve the signed `InRelease` files and reports that the repository is not signed.
+
+## Solution
+1. Remove the proxy environment variables so `apt` can connect directly to the repositories:
+   ```bash
+   unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
+   ```
+2. Ensure the system sources use `https` URLs:
+   ```bash
+   sudo sed -i 's|http://|https://|g' /etc/apt/sources.list.d/ubuntu.sources
+   sudo sed -i 's|http://|https://|g' /etc/apt/sources.list.d/*.list
+   ```
+3. Retry the update:
+   ```bash
+   sudo apt-get update
+   ```
+
+If network access is still blocked after these steps, the container's network policy may prevent external connections and you will need to work without `apt`.
+


### PR DESCRIPTION
## Summary
- expand apt-get troubleshooting guide with guidance on who should run `apt-get update`, when to run it, and when it can be skipped
- document proxy-related root cause and steps for clearing proxy variables and updating APT sources

## Testing
- `pip install -r requirements.txt`
- `apt-get update` *(fails: The repository 'https://apt.llvm.org/noble llvm-toolchain-noble-20 Release' does not have a Release file.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5179ac86483259edd6bf9df79613e