### PR TITLE
Revamp landing screen and add table widget support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@ Simple PySide6 based application for experimenting with financial data.
 
 ## Features
 
-* Modular graph screens that can be added, renamed, detached or removed.
-* Data is stored separately from graph widgets allowing the user to choose
+* Modular graph and table screens that can be added, renamed, detached or
+  removed.
+* Data is stored separately from widgets allowing the user to choose
   which datasets to display.
+* Blank landing screen with quick actions to import a profile or create
+  data; once data is loaded or created the landing view is replaced by
+  the dataset table.
 * Built-in 401(k) dataset support with editable monthly contributions and
   graph/table visualisation. 401(k) data is saved to a local JSON file and
   displayed immediately in an editable table. Columns can be renamed and

--- a/tests/test_main_window_layout.py
+++ b/tests/test_main_window_layout.py
@@ -1,7 +1,7 @@
 import pytest
 
 pytest.importorskip("PySide6.QtWidgets")
-from PySide6.QtWidgets import QApplication, QTabWidget
+from PySide6.QtWidgets import QApplication, QPushButton
 
 from money_metrics.ui.main_window import MainWindow
 from money_metrics.core.profile import AppProfile
@@ -16,17 +16,45 @@ def app():
     yield app
 
 
-def test_default_home_layout_has_tabs(app):
+def test_default_home_layout_has_buttons(app):
     window = MainWindow()
-    assert isinstance(window.centralWidget(), QTabWidget)
-    assert window.centralWidget().tabPosition() == QTabWidget.North
+    central = window.centralWidget()
+    texts = sorted(btn.text() for btn in central.findChildren(QPushButton))
+    assert texts == ["Create Data", "Import Profile"]
 
 
-def test_profile_load_replaces_home_layout(app):
+def test_import_profile_hides_home_layout(app, tmp_path, monkeypatch):
     profile = AppProfile(
-        datasets={"Sample": [1, 2, 3]},
+        datasets={"Sample": [{"balance": 1}, {"balance": 2}]},
         screens=[{"title": "Graph 1", "dataset": "Sample"}],
     )
+    path = tmp_path / "profile.json"
+    profile.save_to_file(path)
+    monkeypatch.setattr(
+        "money_metrics.ui.main_window.QFileDialog.getOpenFileName",
+        lambda *args, **kwargs: (str(path), ""),
+    )
     window = MainWindow()
-    window._apply_profile(profile)
-    assert not isinstance(window.centralWidget(), QTabWidget)
+    window._load_profile_dialog()
+    assert not window.centralWidget().findChildren(QPushButton)
+    assert window.graph_screens and window.graph_screens[0].view_mode == "table"
+
+
+def test_create_data_hides_home_layout(app, monkeypatch):
+    doubles = iter([(100.0, True), (0.01, True)])
+    monkeypatch.setattr(
+        "money_metrics.ui.main_window.QInputDialog.getDouble",
+        lambda *args, **kwargs: next(doubles),
+    )
+    monkeypatch.setattr(
+        "money_metrics.ui.main_window.QInputDialog.getInt",
+        lambda *args, **kwargs: (2, True),
+    )
+    monkeypatch.setattr(
+        "money_metrics.ui.main_window.QFileDialog.getSaveFileName",
+        lambda *args, **kwargs: ("", ""),
+    )
+    window = MainWindow()
+    window._add_401k_dialog()
+    assert not window.centralWidget().findChildren(QPushButton)
+    assert window.graph_screens and window.graph_screens[0].view_mode == "table"


### PR DESCRIPTION
## Summary
- replace tabbed welcome view with blank landing page containing **Import Profile** and **Create Data** buttons
- allow users to spawn table widgets separately from graphs via new menu actions
- hide landing screen once data is imported or created, showing the dataset in a table
- document and test the new default layout and widget options

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5212d88bc8325ad877787aa248181