### PR TITLE
Use full window for plots and tables

### DIFF
--- a/tests/test_main_window_layout.py
+++ b/tests/test_main_window_layout.py
@@ -31,3 +31,9 @@ def test_profile_load_replaces_home_layout(app):
     window = MainWindow()
     window._apply_profile(profile)
     assert not window.centralWidget().findChildren(QPushButton)
+
+
+def test_plot_hides_central_widget(app):
+    window = MainWindow()
+    window.add_plot_screen()
+    assert not window.centralWidget().isVisible()


### PR DESCRIPTION
## Summary
- Hide landing widget when adding plot or table so graphs occupy the full main window
- Ensure loading data or profiles also hides the central widget
- Add regression test verifying the central widget is hidden once a plot is added

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a52d729638832584fb0f40c3bec5da